### PR TITLE
Change login method var user to apply hook authenticate filter

### DIFF
--- a/roundcube_oidc.php
+++ b/roundcube_oidc.php
@@ -98,7 +98,7 @@ use Jumbojett\OpenIDConnectClient;
             ));
 
             // Login to IMAP
-            if ($RCMAIL->login($uid, $password, $imap_server, $auth['cookiecheck'])) {
+            if ($RCMAIL->login($auth['user'], $password, $imap_server, $auth['cookiecheck'])) {
                 $RCMAIL->session->remove('temp');
                 $RCMAIL->session->regenerate_id(false);
                 $RCMAIL->session->set_auth_cookie();


### PR DESCRIPTION
When you are using a additional plugin like `corbosman/dovecot_impersonate` or other plugins that change the uid via the hook. The plugin should change it like in the official rcmail done aswell. 